### PR TITLE
Wrap Y-axis debug feed logging with flag

### DIFF
--- a/YAxis.cpp
+++ b/YAxis.cpp
@@ -124,6 +124,7 @@ void YAxis::Update() {
     _torquePct = _dynamicFeed->updateTorqueMeasurement();
 
     // --- DEBUG: Log torque and feed state for troubleshooting ---
+#ifdef YAXIS_FEED_DEBUG_LOG
     static uint32_t lastDebugLog = 0;
     uint32_t now = ClearCore::TimingMgr.Milliseconds();
     if (now - lastDebugLog > 500) {
@@ -140,6 +141,7 @@ void YAxis::Update() {
         ClearCore::ConnectorUsb.Send(DebugGetCurrentFeedRate() * 100.0f, 1);
         ClearCore::ConnectorUsb.SendLine("%");
     }
+#endif // YAXIS_FEED_DEBUG_LOG
     // ------------------------------------------------------------
 
     // Check if we're in torque-controlled feed mode


### PR DESCRIPTION
## Summary
- wrap torque feed debug log in `YAxis::Update` with `YAXIS_FEED_DEBUG_LOG`

## Testing
- `g++ -fsyntax-only -std=c++17 YAxis.cpp` *(fails: ClearCore.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684860e24c0c8328b5727fd5dc8efe16